### PR TITLE
feat(dap): add environment‐var prompts for coreclr adapter

### DIFF
--- a/lua/netcoredbg-macOS-arm64/init.lua
+++ b/lua/netcoredbg-macOS-arm64/init.lua
@@ -1,82 +1,79 @@
--- myplugin/init.lua
 local M = {}
 
-
 local function get_plugin_directory()
-  local str = debug.getinfo(1, "S").source:sub(2)
-  str = str:match("(.*/)")               -- Get the directory of the current file
-  return str:gsub("/[^/]+/[^/]+/$", "/") -- Go up two directories
+	local str = debug.getinfo(1, "S").source:sub(2)
+	str = str:match("(.*/)")
+	return str:gsub("/[^/]+/[^/]+/$", "/")
 end
 
 local plugin_directory = get_plugin_directory()
-local netcoredbg_path = plugin_directory .. 'netcoredbg/netcoredbg'
+local netcoredbg_path = plugin_directory .. "netcoredbg/netcoredbg"
 
+M.setup = function(dap, env_vars)
+	dap.adapters.coreclr = {
+		type = "executable",
+		command = netcoredbg_path,
+		args = { "--interpreter=vscode" },
+	}
 
-M.setup = function(dap)
-  dap.adapters.coreclr = {
-    type = 'executable',
-    command = netcoredbg_path,
-    args = { '--interpreter=vscode' }
-  }
+	local function getCurrentFileDirName()
+		local fullPath = vim.fn.expand("%:p:h")
+		local dirName = fullPath:match("([^/\\]+)$")
+		return dirName
+	end
 
-  local function getCurrentFileDirName()
-    local fullPath = vim.fn.expand('%:p:h')      -- Get the full path of the directory containing the current file
-    local dirName = fullPath:match("([^/\\]+)$") -- Extract the directory name
-    return dirName
-  end
+	local function file_exists(name)
+		local f = io.open(name, "r")
+		if f ~= nil then
+			io.close(f)
+			return true
+		else
+			return false
+		end
+	end
 
-  local function file_exists(name)
-    local f = io.open(name, "r")
-    if f ~= nil then
-      io.close(f)
-      return true
-    else
-      return false
-    end
-  end
+	local function get_dll_path()
+		local debugPath = vim.fn.expand("%:p:h") .. "/bin/Debug"
+		if not file_exists(debugPath) then
+			return vim.fn.getcwd()
+		end
+		local command = 'find "' .. debugPath .. '" -maxdepth 1 -type d -name "*net*" -print -quit'
+		local handle = io.popen(command)
+		local result = handle:read("*a")
+		handle:close()
+		result = result:gsub("[\r\n]+$", "")
+		if result == "" then
+			return debugPath
+		else
+			local potentialDllPath = result .. "/" .. getCurrentFileDirName() .. ".dll"
+			if file_exists(potentialDllPath) then
+				return potentialDllPath
+			else
+				return result == "" and debugPath or result .. "/"
+			end
+		end
+	end
 
-  local function get_dll_path()
-    local debugPath = vim.fn.expand('%:p:h') .. '/bin/Debug'
-    if not file_exists(debugPath) then
-      return vim.fn.getcwd()
-    end
-    local command = 'find "' .. debugPath .. '" -maxdepth 1 -type d -name "*net*" -print -quit'
-    local handle = io.popen(command)
-    local result = handle:read("*a")
-    handle:close()
-    result = result:gsub("[\r\n]+$", "") -- Remove trailing newline and carriage return
-    if result == "" then
-      return debugPath
-    else
-      local potentialDllPath = result .. '/' .. getCurrentFileDirName() .. '.dll'
-      if file_exists(potentialDllPath) then
-        return potentialDllPath
-      else
-        return result == "" and debugPath or result .. '/'
-      end
-      --        return result .. '/' -- Adds a trailing slash if a net folder is found
-    end
-  end
+	dap.configurations.cs = {
+		{
 
-  dap.configurations.cs = {
-    {
-      type = 'coreclr',
-      name = 'NetCoreDbg: Launch',
-      request = 'launch',
-      cwd = '${fileDirname}',
-      program = function()
-        return vim.fn.input('Path to dll', get_dll_path(), 'file')
-      end,
-      env = {
-        ASPNETCORE_ENVIRONMENT = function()
-          return vim.fn.input("ASPNETCORE_ENVIRONMENT: ", "Development")
-        end,
-        ASPNETCORE_URL = function()
-          return vim.fn.input("ASPNETCORE_URL: ", "http://localhost:5000")
-        end,
-      }
-    },
-  }
+			type = "coreclr",
+			name = "NetCoreDbg: Launch",
+			request = "launch",
+			cwd = "${fileDirname}",
+			program = function()
+				return vim.fn.input("Path to dll", get_dll_path(), "file")
+			end,
+			env = vim.tbl_extend("force", {
+				ASPNETCORE_ENVIRONMENT = function()
+					return vim.fn.input("ASPNETCORE_ENVIRONMENT: ", "Development")
+				end,
+				ASPNETCORE_URL = function()
+					return vim.fn.input("ASPNETCORE_URL: ", "http://localhost:5000")
+				end,
+			}, env_vars or {}),
+		},
+	}
 end
 
 return M


### PR DESCRIPTION
**This PR integrates the plugin to automatically load environment variables from a .env file in the project root directory.**

It then passes selected environment variables to the netcoredbg-macOS-arm64.nvim debug adapter configuration, allowing users to easily inject project-specific environment settings (such as connection strings and JWT keys) into their debugging sessions.

**How to use**
Add the following snippet to your Neovim config to enable this feature:

```
{
  "Cliffback/netcoredbg-macOS-arm64.nvim",
  dependencies = {
    "mfussenegger/nvim-dap",
    "rcarriga/nvim-dap-ui",
    "ellisonleao/dotenv.nvim",
  },
  config = function()
    local dap = require("dap")
    local env_path = vim.fn.getcwd() .. "/.env"

    if vim.loop.fs_stat(env_path) then
      require("dotenv").setup({ enable_on_load = true, verbose = false })
      require("dotenv").command()
    end

    local env_vars = {
      ConnectionStrings__DefaultConnection = vim.env.ConnectionStrings__DefaultConnection,
      JWT__Issuer = vim.env.JWT__Issuer,
      JWT__Audience = vim.env.JWT__Audience,
      JWT__Key = vim.env.JWT__Key,
    }

    require("netcoredbg-macOS-arm64").setup(dap, env_vars)
  end,
}
```

> Notes


This feature is opt-in: if no .env file is found, behavior remains unchanged.

Environment variables passed to the plugin can be extended as needed.