### PR TITLE
feat: add netcoredbg adapter alias for compatibility

### DIFF
--- a/lua/netcoredbg-macOS-arm64/init.lua
+++ b/lua/netcoredbg-macOS-arm64/init.lua
@@ -97,9 +97,9 @@ M.setup = function()
   }
   
   dap.adapters.netcoredbg = {
-    type = 'executable',
-    command = dap.adapters.coreclr.command,
-    args = { '--interpreter=vscode' },
+	  type = "executable",
+	  command = netcoredbg_path,
+	  args = { "--interpreter=vscode" },
   }
 
   -- 4. Register C# configuration

--- a/lua/netcoredbg-macOS-arm64/init.lua
+++ b/lua/netcoredbg-macOS-arm64/init.lua
@@ -19,6 +19,12 @@ M.setup = function(dap, env_vars)
     args = { '--interpreter=vscode' }
   }
 
+  dap.adapters.netcoredbg = {
+    type = 'executable',
+    command = dap.adapters.coreclr.command,
+    args = { '--interpreter=vscode' },
+  }
+
   local function getCurrentFileDirName()
     local fullPath = vim.fn.expand('%:p:h')      -- Get the full path of the directory containing the current file
     local dirName = fullPath:match("([^/\\]+)$") -- Extract the directory name

--- a/lua/netcoredbg-macOS-arm64/init.lua
+++ b/lua/netcoredbg-macOS-arm64/init.lua
@@ -97,9 +97,9 @@ M.setup = function()
   }
   
   dap.adapters.netcoredbg = {
-	  type = "executable",
-	  command = netcoredbg_path,
-	  args = { "--interpreter=vscode" },
+	type = "executable",
+	command = netcoredbg_path,
+	args = { "--interpreter=vscode" },
   }
 
   -- 4. Register C# configuration


### PR DESCRIPTION
Thanks to @nabsergey for the suggestion

Sets up a netcoredbg aliases for the coreclr adapter to make it be more compatible, like getting unit tests in debug mode to work.

Closes #7 